### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#mac
+.DS_Store


### PR DESCRIPTION
This is so mac users like me can send pull requests without the .DS_Store file that are auto-generatored by OS-X, since most people don't like those. See: http://en.wikipedia.org/wiki/.DS_Store
